### PR TITLE
Add MSTest lab skeleton

### DIFF
--- a/LabUnitTesting/BusinessLogic.Tests/BusinessLogic.Tests.csproj
+++ b/LabUnitTesting/BusinessLogic.Tests/BusinessLogic.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Test.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.2" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BusinessLogic\BusinessLogic.csproj" />
+  </ItemGroup>
+</Project>

--- a/LabUnitTesting/BusinessLogic.Tests/OrderServiceTests.cs
+++ b/LabUnitTesting/BusinessLogic.Tests/OrderServiceTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using BusinessLogic;
+
+namespace BusinessLogic.Tests;
+
+[TestClass]
+public class OrderServiceTests
+{
+    [TestMethod]
+    public void AddItem_ShouldIncreaseSubtotal()
+    {
+        // Arrange
+        var svc = new OrderService();
+
+        // Act
+        svc.AddItem("ABC", 2, 10m);
+        var subtotal = svc.CalculateSubtotal();
+
+        // Assert
+        Assert.AreEqual(20m, subtotal);
+    }
+}

--- a/LabUnitTesting/BusinessLogic/BusinessLogic.csproj
+++ b/LabUnitTesting/BusinessLogic/BusinessLogic.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/LabUnitTesting/BusinessLogic/OrderService.cs
+++ b/LabUnitTesting/BusinessLogic/OrderService.cs
@@ -1,0 +1,70 @@
+namespace BusinessLogic;
+
+public interface IInventoryClient
+{
+    ValueTask<int> GetAvailableAsync(string sku, CancellationToken ct = default);
+}
+
+public interface IClock
+{
+    DateTime UtcNow { get; }
+}
+
+public class OrderService
+{
+    private readonly List<(string sku, int qty, decimal price)> _items = [];
+    private readonly IInventoryClient? _inventory;
+    private readonly IClock? _clock;
+
+    public OrderService()
+    {
+    }
+
+    public OrderService(IInventoryClient inventory, IClock? clock = null)
+    {
+        _inventory = inventory;
+        _clock = clock;
+    }
+
+    public void AddItem(string sku, int qty, decimal unitPrice)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(qty);
+        ArgumentOutOfRangeException.ThrowIfNegative(unitPrice);
+        _items.Add((sku, qty, unitPrice));
+    }
+
+    // Placeholder for async AddItem that checks inventory
+    public virtual async Task AddItemAsync(string sku, int qty, decimal unitPrice, CancellationToken ct = default)
+    {
+        if (_inventory is not null)
+        {
+            var available = await _inventory.GetAvailableAsync(sku, ct);
+            if (qty > available)
+            {
+                throw new InvalidOperationException("Insufficient stock");
+            }
+        }
+        AddItem(sku, qty, unitPrice);
+    }
+
+    public decimal CalculateSubtotal() => _items.Sum(i => i.qty * i.price);
+
+    // Placeholder for total calculation with discounts
+    public decimal CalculateTotal()
+    {
+        var subtotal = CalculateSubtotal();
+        return subtotal switch
+        {
+            >= 1000m => subtotal * 0.90m,
+            >= 500m => subtotal * 0.95m,
+            _ => subtotal
+        };
+    }
+
+    // Placeholder for async checkout returning IAsyncEnumerable<string>
+    public virtual async IAsyncEnumerable<string> CheckoutAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.Yield();
+        yield return "Checked out";
+    }
+}

--- a/LabUnitTesting/LabUnitTesting.sln
+++ b/LabUnitTesting/LabUnitTesting.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BusinessLogic", "BusinessLogic\BusinessLogic.csproj", "{e7eb7646-2280-43e5-ae37-29c4f5ff87f5}"
+EndProject
+Project("{3AC096D0-A1C2-E12C-1390-A8335801FDAB}") = "BusinessLogic.Tests", "BusinessLogic.Tests\BusinessLogic.Tests.csproj", "{ff1fd903-af15-427c-923b-8a66e37153b2}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{e7eb7646-2280-43e5-ae37-29c4f5ff87f5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{e7eb7646-2280-43e5-ae37-29c4f5ff87f5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{e7eb7646-2280-43e5-ae37-29c4f5ff87f5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{e7eb7646-2280-43e5-ae37-29c4f5ff87f5}.Release|Any CPU.Build.0 = Release|Any CPU
+{ff1fd903-af15-427c-923b-8a66e37153b2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{ff1fd903-af15-427c-923b-8a66e37153b2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{ff1fd903-af15-427c-923b-8a66e37153b2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{ff1fd903-af15-427c-923b-8a66e37153b2}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/LabUnitTesting/docs/Frameworks_At_A_Glance.md
+++ b/LabUnitTesting/docs/Frameworks_At_A_Glance.md
@@ -1,0 +1,11 @@
+# Quick Reading — Unit-Test Frameworks at a Glance
+
+|               | MSTest | xUnit.net | NUnit |
+|---------------|--------|----------|-------|
+| **Origin**    | Built-in Visual Studio team | OSS, ex‑ASP.NET team | OSS, inspired by JUnit |
+| **Core Attribute** | `[TestMethod]` | `[Fact]` | `[Test]` |
+| **Parameterized** | `[DataTestMethod]` + `[DataRow]` / `[DynamicData]` | `[Theory]` + `[InlineData]` / `[MemberData]` | `[TestCase]` / `[TestCaseSource]` |
+| **Setup / Teardown** | `[TestInitialize]` / `[TestCleanup]` | constructor / `IDisposable` | `[SetUp]` / `[TearDown]` |
+| **Philosophy** | Attribute-oriented, tight VS integration | "Code-like tests", minimal magic | Familiar JUnit style |
+
+We focus on MSTest because the existing codebase already uses it. Equivalent concepts in xUnit and NUnit are noted where relevant throughout the lab.

--- a/LabUnitTesting/docs/Part0_Setup.md
+++ b/LabUnitTesting/docs/Part0_Setup.md
@@ -1,0 +1,18 @@
+# Part 0 – Setup
+
+Follow these commands to create the solution skeleton. They are reproduced here in case you wish to recreate the structure from scratch.
+
+```bash
+mkdir LabUnitTesting && cd LabUnitTesting
+
+dotnet new sln -n LabUnitTesting
+dotnet new classlib -n BusinessLogic
+dotnet new mstest -n BusinessLogic.Tests
+
+dotnet sln add BusinessLogic/ BusinessLogic.Tests/
+dotnet add BusinessLogic.Tests reference BusinessLogic/
+```
+
+At this stage, the `BusinessLogic` project contains the `OrderService` class and the test project references it. Build the solution to ensure everything compiles.
+
+Checkpoint: `git commit -m "scaffold order service"`

--- a/LabUnitTesting/docs/Part1_Hello_MSTest.md
+++ b/LabUnitTesting/docs/Part1_Hello_MSTest.md
@@ -1,0 +1,25 @@
+# Part 1 – Hello MSTest
+
+Create `OrderServiceTests.cs` inside `BusinessLogic.Tests` with the following test:
+
+```csharp
+[TestClass]
+public class OrderServiceTests
+{
+    [TestMethod]
+    public void AddItem_ShouldIncreaseSubtotal()
+    {
+        // Arrange
+        var svc = new OrderService();
+
+        // Act
+        svc.AddItem("ABC", 2, 10m);
+        var subtotal = svc.CalculateSubtotal();
+
+        // Assert
+        Assert.AreEqual(20m, subtotal);
+    }
+}
+```
+
+Run `dotnet test`. The first run fails (red). Implement `AddItem` in `OrderService` and rerun until the test passes (green).

--- a/LabUnitTesting/docs/Part2_AAA.md
+++ b/LabUnitTesting/docs/Part2_AAA.md
@@ -1,0 +1,5 @@
+# Part 2 – Arrange, Act, Assert Pattern
+
+Refactor the previous test to use explicit `Arrange`, `Act`, and `Assert` sections and adopt a descriptive naming style of `MethodUnderTest_State_Expected`.
+
+Discuss with your partner whether multiple asserts belong in a single test. Split tests when separate concepts are being verified.

--- a/LabUnitTesting/docs/Part3_Parameterized.md
+++ b/LabUnitTesting/docs/Part3_Parameterized.md
@@ -1,0 +1,18 @@
+# Part 3 – Parameterized Tests
+
+Extend `OrderService` with a `CalculateTotal()` method that applies discounts:
+
+```csharp
+public decimal CalculateTotal()
+{
+    var subtotal = CalculateSubtotal();
+    return subtotal switch
+    {
+        >= 1000m => subtotal * 0.90m, // 10 % off big orders
+        >= 500m  => subtotal * 0.95m,
+        _        => subtotal
+    };
+}
+```
+
+Write a `[DataTestMethod]` in `OrderServiceTests` covering boundaries at `499.99`, `500`, `999.99`, and `1000`.

--- a/LabUnitTesting/docs/Part4_Mocking.md
+++ b/LabUnitTesting/docs/Part4_Mocking.md
@@ -1,0 +1,12 @@
+# Part 4 – Mocking with Moq
+
+Introduce an external dependency `IInventoryClient`:
+
+```csharp
+public interface IInventoryClient
+{
+    ValueTask<int> GetAvailableAsync(string sku, CancellationToken ct = default);
+}
+```
+
+Modify `OrderService` to accept this client in the constructor and check stock before adding items. Use `Moq` to verify that `GetAvailableAsync` is called exactly once when stock is sufficient.

--- a/LabUnitTesting/docs/Part5_Errors.md
+++ b/LabUnitTesting/docs/Part5_Errors.md
@@ -1,0 +1,8 @@
+# Part 5 – Error Paths and Exceptions
+
+Write a test that adding more than the available stock throws `InvalidOperationException`.
+
+```csharp
+await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+    svc.AddItemAsync("ABC", 10, 5m));
+```

--- a/LabUnitTesting/docs/Part6_Async.md
+++ b/LabUnitTesting/docs/Part6_Async.md
@@ -1,0 +1,3 @@
+# Part 6 – Async/Await Testing
+
+Suppose `CheckoutAsync` returns an `IAsyncEnumerable<string>` of status messages. Test it using `await foreach` or by calling `.ToListAsync()`.

--- a/LabUnitTesting/docs/Part7_Refactor.md
+++ b/LabUnitTesting/docs/Part7_Refactor.md
@@ -1,0 +1,3 @@
+# Part 7 – Refactor for Testability
+
+Replace any uses of `DateTime.UtcNow` with an injected `IClock` interface so that time-based logic such as Black Friday pricing can be tested deterministically.

--- a/LabUnitTesting/docs/Part8_Coverage.md
+++ b/LabUnitTesting/docs/Part8_Coverage.md
@@ -1,0 +1,11 @@
+# Part 8 – Coverage Tools
+
+Run tests with Coverlet to enforce 90% line coverage locally:
+
+```bash
+dotnet test /p:CollectCoverage=true \
+             /p:CoverletOutputFormat="cobertura" \
+             /p:Threshold=90 /p:ThresholdType=line
+```
+
+The command exits non-zero if coverage is below the threshold.

--- a/LabUnitTesting/docs/Part9_Challenge.md
+++ b/LabUnitTesting/docs/Part9_Challenge.md
@@ -1,0 +1,3 @@
+# Part 9 – Challenge
+
+Add extra business rules such as taxes, shipping fees, and order cancellation. Achieve at least 90% line coverage and 100% branch coverage. Try mutating the code (for example, change a discount percentage) and ensure tests fail, building confidence in your suite.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# CSharp_Unit_Test_Lab
+# C# Unit Testing Lab Skeleton
+
+This repository contains the starting point for a hands‑on unit testing lab using **MSTest**. The project grows through a series of guided parts. Each part lives under `LabUnitTesting/docs` with instructions.
+
+## Structure
+
+```
+LabUnitTesting/
+  BusinessLogic/           # Class library under test
+  BusinessLogic.Tests/     # MSTest project
+  LabUnitTesting.sln       # Solution tying projects together
+  docs/                    # Step-by-step instructions
+```
+
+Begin with **docs/Part0_Setup.md** and work through the parts in order. Refer to **docs/Frameworks_At_A_Glance.md** for a comparison of popular .NET test frameworks.


### PR DESCRIPTION
## Summary
- scaffold `BusinessLogic` and `BusinessLogic.Tests` projects
- provide initial `OrderService` class and basic MSTest
- add docs for each lab part and framework comparison
- update repo README with instructions

## Testing
- `dotnet` command not found; unable to run tests

------
https://chatgpt.com/codex/tasks/task_e_685c2d0fab308325b52243015a45790b